### PR TITLE
Fix casts with const pointers

### DIFF
--- a/hellow_minimal_irt.c
+++ b/hellow_minimal_irt.c
@@ -31,7 +31,7 @@ static void __libnacl_mandatory_irt_query(const char *interface,
                                 sizeof(__libnacl_irt_##name))
 
 void _start(uint32_t *info) {
-  Elf32_auxv_t *auxv = nacl_startup_auxv(info);
+  const Elf32_auxv_t *auxv = nacl_startup_auxv(info);
   grok_auxv(auxv);
   DO_QUERY(NACL_IRT_BASIC_v0_1, basic);
   DO_QUERY(NACL_IRT_FDIO_v0_1, fdio);

--- a/nacl_irt_interfaces.h
+++ b/nacl_irt_interfaces.h
@@ -100,21 +100,21 @@ static inline int nacl_startup_argc(const uint32_t info[]) {
   return info[NACL_STARTUP_ARGC];
 }
 
-static inline char **nacl_startup_argv(const uint32_t *info) {
-  return (char **) &info[NACL_STARTUP_ARGV];
+static inline char* const *nacl_startup_argv(const uint32_t *info) {
+  return (char* const*) &info[NACL_STARTUP_ARGV];
 }
 
 static inline int nacl_startup_envc(const uint32_t info[]) {
   return info[NACL_STARTUP_ENVC];
 }
 
-static inline char **nacl_startup_envp(const uint32_t *info) {
+static inline char* const *nacl_startup_envp(const uint32_t *info) {
   return &nacl_startup_argv(info)[nacl_startup_argc(info) + 1];
 }
 
-static inline Elf32_auxv_t *nacl_startup_auxv(const uint32_t *info) {
-  char **envend = &nacl_startup_envp(info)[nacl_startup_envc(info) + 1];
-  return (Elf32_auxv_t *) envend;
+static inline const Elf32_auxv_t *nacl_startup_auxv(const uint32_t *info) {
+  char* const* envend = &nacl_startup_envp(info)[nacl_startup_envc(info) + 1];
+  return (const Elf32_auxv_t *) envend;
 }
 
 #endif


### PR DESCRIPTION
Fix the removal of the const qualifier. Simply keep the const by using pointers to const values.
